### PR TITLE
Add docsly to collect actionable feedback

### DIFF
--- a/components/Docsly.tsx
+++ b/components/Docsly.tsx
@@ -1,0 +1,15 @@
+import '@docsly/react/styles.css';
+
+import Docsly from '@docsly/react';
+import { usePathname } from 'next/navigation';
+
+export default function DocslyClient() {
+  const pathname = usePathname();
+
+  return (
+    <Docsly
+      publicId={'public_L5LFPi0sz2uQ3WlnZN5kp9PgIQA07MMcveB6ramMJ2nFxjZ7K9zPk7M1nO0VyvZK'}
+      pathname={pathname}
+    />
+  );
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://docs.plain.com",
   "dependencies": {
+    "@docsly/react": "1.8.6",
     "clsx": "1.2.1",
     "next": "13.0.6",
     "nextra": "2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,9 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
+  '@docsly/react':
+    specifier: 1.8.6
+    version: 1.8.6(csstype@3.1.1)(react-dom@18.2.0)(react@18.2.0)
   clsx:
     specifier: 1.2.1
     version: 1.2.1
@@ -92,6 +91,24 @@ packages:
     resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
     dev: false
 
+  /@docsly/react@1.8.6(csstype@3.1.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-FwcVeTYsZnOMIFYgW0R9/0xaWKWfzvW4eKA9QjJApXKbfGFHgzm0tWEmVf9TyZgsA3qoI+0qaUuJ3JlQrdONXg==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@heroicons/react': 2.0.18(react@18.2.0)
+      clsx: 1.2.1
+      dayjs: 1.11.8
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-error-boundary: 3.1.4(react@18.2.0)
+      react-hot-toast: 2.4.1(csstype@3.1.1)(react-dom@18.2.0)(react@18.2.0)
+      swr: 2.2.2(react@18.2.0)
+    transitivePeerDependencies:
+      - csstype
+    dev: false
+
   /@eslint-community/eslint-utils@4.4.0(eslint@8.42.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -139,6 +156,14 @@ packages:
       client-only: 0.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@heroicons/react@2.0.18(react@18.2.0):
+    resolution: {integrity: sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==}
+    peerDependencies:
+      react: '>= 16'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /@humanwhocodes/config-array@0.11.10:
@@ -2341,6 +2366,14 @@ packages:
       slash: 4.0.0
     dev: true
 
+  /goober@2.1.13(csstype@3.1.1):
+    resolution: {integrity: sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.1
+    dev: false
+
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -4176,6 +4209,30 @@ packages:
       scheduler: 0.23.0
     dev: false
 
+  /react-error-boundary@3.1.4(react@18.2.0):
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.22.3
+      react: 18.2.0
+    dev: false
+
+  /react-hot-toast@2.4.1(csstype@3.1.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      goober: 2.1.13(csstype@3.1.1)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - csstype
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
@@ -4677,6 +4734,16 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /swr@2.2.2(react@18.2.0):
+    resolution: {integrity: sha512-CbR41AoMD4TQBQw9ic3GTXspgfM9Y8Mdhb5Ob4uIKXhWqnRLItwA5fpGvB7SmSw3+zEjb0PdhiEumtUvYoQ+bQ==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      client-only: 0.0.1
+      react: 18.2.0
+      use-sync-external-store: 1.2.0(react@18.2.0)
+    dev: false
+
   /synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -4972,6 +5039,14 @@ packages:
       punycode: 2.3.0
     dev: true
 
+  /use-sync-external-store@1.2.0(react@18.2.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -5162,3 +5237,7 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -2,6 +2,8 @@ import { useRouter } from 'next/router';
 import { DocsThemeConfig, useConfig } from 'nextra-theme-docs';
 import React from 'react';
 
+import DocslyClient from './components/Docsly';
+
 function Logo() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2561 769" height={20} fill="none">
@@ -81,7 +83,12 @@ const config: DocsThemeConfig = {
   },
 
   footer: {
-    text: <span>© Not Just Tickets Limited – {new Date().getFullYear()}</span>,
+    text: (
+      <>
+        <DocslyClient />
+        <span>© Not Just Tickets Limited – {new Date().getFullYear()}</span>
+      </>
+    ),
   },
 };
 


### PR DESCRIPTION
## Description

I saw the note about leaving feedback using GitHub on your documentation website. Although it's a good initiative, you can reduce the friction by adding contextual (inline) feedback collection to your documentation. This not only provides a better UX for the reader but also gives more contextual information to the person reading the suggestion. 

[Docsly](https://docsly.dev) is a feedback tool crafted for developer documentation. It lets the readers leave contextual feedback  (comments) on the documentation website and helps the maintainer by showing the feedback exactly where the user left it. It also gives the users the option to leave a like/dislike to help your team get a sense of what content is helpful for the users.

## How will it look

docsly works in private mode by default: everyone can leave a comment on your docs but only your team can see them. Here's a screenshot from your docs + docsly:

![image](https://github.com/team-plain/docs/assets/28081510/0033354f-1b0b-43b2-b7e7-9ccc2e2d288b)

### Example project for preview

[Clerk](https://clerk.com/docs), [Tigris](https://www.tigrisdata.com/docs/), and [Dyte](https://docs.dyte.io) are using docsly in **production** and receive valuable feedback.

Testimonial: https://twitter.com/james_r_perkins/status/1664672677410353152

YouTube demo: https://www.youtube.com/watch?v=65Qs50vVumw&ab_channel=JamesPerkins

### Todo

- [ ] Sign up on [docsly.dev ](https://docsly.dev/dashboard)for a fresh account for maintainers

### Any questions?

I'll keep an eye on this PR but in case you want more personalized help, feel free to contact me at: anshuman@docsly.dev or join the [Discord](https://discord.gg/9hw6kH5hhm).

