### PR TITLE
Routing rules order

### DIFF
--- a/api-reference/customer-cards/protocol.mdx
+++ b/api-reference/customer-cards/protocol.mdx
@@ -82,13 +82,13 @@ The request deduplication logic for customer card configs is:
 
 ## Response
 
-<Callout type="warning" emoji="⚠️">
+<Warning>
 
 For each key requested a corresponding card **MUST** be returned in the response, otherwise an integration error will be returned for that card.
 
 Any extra cards in the response will be ignored.
 
-</Callout>
+</Warning>
 
 Your API must respond with a **`200` status code** or the response body won't be processed and will be treated as an error.
 

--- a/api-reference/migrate-to-threads.mdx
+++ b/api-reference/migrate-to-threads.mdx
@@ -28,10 +28,10 @@ Or if you are using _any_ of the following webhooks :
 
 If you run into **any** issues, please reach out to us via the app (**⌘ + K** and then search for "Question") or email us at [help@plain.com](mailto:help@plain.com).
 
-<Callout type="info" emoji="👉">
+<Note>
   Once you have fully migrated across, please let us know and we will enable a feature flag for your
   workspace giving you the full benefits of threads within Plain.
-</Callout>
+</Note>
 
 ## New data model
 

--- a/email/receiving.mdx
+++ b/email/receiving.mdx
@@ -55,3 +55,8 @@ If your email provider is not Google, you can still set up email forwarding in d
     ...and That's it! 💅
   </Step>
 </Steps>
+
+<Tip>
+  If you have existing email routing rules they can sometimes conflict with ones you add for Plain.
+  For optimal reliability always reorder the Plain ones to apply first.
+</Tip>

--- a/email/receiving.mdx
+++ b/email/receiving.mdx
@@ -6,12 +6,12 @@ To receive emails, you need to set up email forwarding from your company's suppo
 to your Plain workspace's inbound email address. Your workspace's inbound email address ends with `@inbound.postmark.app` and
 can be found in under **Settings** → **Email**.
 
-<Callout type="info" emoji="️✋">
+<Note>
 This assumes you use Google Workspace (formerly called Google Apps) to manage your domain's emails.
 
 If your email provider is not Google, you can still set up email forwarding in different ways, such as with your domain registrar (e.g. [DNSimple](https://support.dnsimple.com/articles/email-forwarding/)) or your email provider (e.g. [Microsoft 365](https://learn.microsoft.com/en-us/microsoft-365/admin/email/configure-email-forwarding)).
 
-</Callout>
+</Note>
 
 <Steps>
   <Step title="Go to your Gmail routing configuration">


### PR DESCRIPTION
Added a tip about email routing rule order which we just debugged for a Plain user.

Also spotted we were trying to use a `Callout` component which doesn't exist in Mintlify