### PR TITLE
Docs fixes

### DIFF
--- a/_snippets/typescript-sdk/reply-to-thread.mdx
+++ b/_snippets/typescript-sdk/reply-to-thread.mdx
@@ -1,0 +1,17 @@
+```tsx
+import { PlainClient } from '@team-plain/typescript-sdk';
+
+const client = new PlainClient({ apiKey: 'plainApiKey_xxx' });
+
+const res = await client.replyToThread({
+  threadId: 'th_01HD1G6649R1DK061W27VBT7QB',
+  textContent: 'The plain text version of your reply goes here.',
+  markdownContent: 'The markdown **version** of your _reply_ goes here.',
+});
+
+if (res.error) {
+  console.error(res.error);
+} else {
+  console.log(res.data);
+}
+```

--- a/api-reference/graphql/messaging/reply-to-thread.mdx
+++ b/api-reference/graphql/messaging/reply-to-thread.mdx
@@ -17,7 +17,7 @@ If it is not possible to reply to this thread, you will get the mutation error c
 
       <Snippet file="typescript-sdk/reply-to-thread.mdx" />
 
-      Where `result.data` is:
+      Where `res.data` is:
 
       <Snippet file="typescript-sdk/reply-to-thread-response.mdx" />
 

--- a/api-reference/graphql/messaging/reply-to-thread.mdx
+++ b/api-reference/graphql/messaging/reply-to-thread.mdx
@@ -9,13 +9,6 @@ You can reply to a thread using the `replyToThread` mutation. The call to this m
 
 If it is not possible to reply to this thread, you will get the mutation error code [`cannot_reply_to_thread`](/api-reference/graphql/error-codes#cannot_reply_to_thread) and a message indicating why.
 
-<Info>
-  Using the `replyToThread` mutation is the recommended way to create a simple auto-responder with
-  Plain. To do it, you should subscribe to the
-  [`thread.thread_created`](/api-reference/webhooks/thread-created) event and use use this mutation
-  whenever you get this event.
-</Info>
-
 <Tabs>
   <Tab title="Typescript SDK">
       Only one permission is needed:

--- a/api-reference/graphql/messaging/send-email.mdx
+++ b/api-reference/graphql/messaging/send-email.mdx
@@ -2,7 +2,7 @@
 title: 'Send new emails'
 ---
 
-You can send new outbound emails to customers with the `sendNewEmail` API. This is useful for proactively reaching out about issues.
+As well as creating outbound emails in the UI you can also send them with the `sendNewEmail` API. This is useful for proactively reaching out about issues.
 
 <Tabs>
   <Tab title="Typescript SDK">


### PR DESCRIPTION
- A user assumed the send email docs meant you couldn't do outbound via the UI, so make it clear you can
- Fix reply to thread docs