### PR TITLE
clarify how we classify different slack channels and what's the difference between them

### DIFF
--- a/slack.mdx
+++ b/slack.mdx
@@ -29,7 +29,7 @@ Once you’ve set up the integration in Plain, go to the Slack channels you want
 ></video>
 
 <Warning>
-  When Plain is added to a channel, we automatically classify it as a Customer channel if it's a slack connect channel or one for [internal discussions](/thread-discussions) otherwise.
+  When Plain is added to a channel, we automatically classify it as a Customer channel if it's a _Slack Connect_ channel or one for [internal discussions](/thread-discussions) otherwise.
 
 For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
 

--- a/slack.mdx
+++ b/slack.mdx
@@ -31,9 +31,10 @@ Once you’ve set up the integration in Plain, go to the Slack channels you want
 <Warning>
   When Plain is added to a channel, we automatically classify it as a Customer channel if it's a slack connect channel or one for [internal discussions](/thread-discussions) otherwise.
 
-  For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
+For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
 
-  In discussion channels, on the other hand, we only ingest messages related to an on-going discussion.
+In discussion channels, on the other hand, we only ingest messages related to an on-going discussion.
+
 </Warning>
 
 **3 Start responding 💬**

--- a/slack.mdx
+++ b/slack.mdx
@@ -28,6 +28,14 @@ Once you’ve set up the integration in Plain, go to the Slack channels you want
   src="https://static-assets.plain.com/docs/slack/add-to-slack.mp4"
 ></video>
 
+<Warning>
+  When Plain is added to a channel, we automatically classify it as a Customer channel if it's a slack connect channel or one for [internal discussions](/thread-discussions) otherwise.
+
+  For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
+
+  In discussion channels, on the other hand, we only ingest messages related to an on-going discussion.
+</Warning>
+
 **3 Start responding 💬**
 
 Slack messages from the authorized channels will begin appearing as threads in Plain. To respond, press `R` and begin typing in Plain. Your responses will appear in Slack as if you are responding directly in the app.

--- a/thread-discussions.mdx
+++ b/thread-discussions.mdx
@@ -13,6 +13,14 @@ For your convenience, the discussion will also be visible in the Plain thread.
 
 To enable this functionality, you will need to setup your [Slack integration](/slack) and add the Plain bot to your channel.
 
+<Warning>
+  When Plain is added to a channel, we automatically classify it as a [Customer channel](/slack/how-slack-messages-create-threads) if it's a slack connect channel or one for internal discussions otherwise.
+
+  For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
+
+  In discussion channels, on the other hand, we only ingest messages related to an on-going discussion.
+</Warning>
+
 For good data hygiene, we don't start discussions on all links to a Plain thread.
 We will not start a discussion if:
 

--- a/thread-discussions.mdx
+++ b/thread-discussions.mdx
@@ -24,8 +24,8 @@ To enable this functionality, you will need to setup your [Slack integration](/s
 For good data hygiene, we don't start discussions on all links to a Plain thread.
 We will not start a discussion if:
 
-- the link is posted by someone who is not a user in Plain
-- the link is posted in a private channel Plain doesn't have access to
-- the link is posted in a customer channel (typically Slack Connect), although you can always adjust this from your Slack settings
+- the link is posted by someone who is not a user in Plain.
+- the link is posted in a private channel Plain doesn't have access to.
+- the link is posted in a customer channel (typically Slack Connect), although you can always adjust this from your Slack settings.
 
 If you want to opt out of unfurling completely, you can disable thread discussions and link unfurling in your Slack integration settings.

--- a/thread-discussions.mdx
+++ b/thread-discussions.mdx
@@ -16,9 +16,10 @@ To enable this functionality, you will need to setup your [Slack integration](/s
 <Warning>
   When Plain is added to a channel, we automatically classify it as a [Customer channel](/slack/how-slack-messages-create-threads) if it's a slack connect channel or one for internal discussions otherwise.
 
-  For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
+For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
 
-  In discussion channels, on the other hand, we only ingest messages related to an on-going discussion.
+In discussion channels, on the other hand, we only ingest messages related to an on-going discussion.
+
 </Warning>
 
 For good data hygiene, we don't start discussions on all links to a Plain thread.

--- a/thread-discussions.mdx
+++ b/thread-discussions.mdx
@@ -26,6 +26,6 @@ We will not start a discussion if:
 
 - the link is posted by someone who is not a user in Plain
 - the link is posted in a private channel Plain doesn't have access to
-- the link is posted in a customer channel such as Slack Connect, although you can always adjust this from your Slack settings
+- the link is posted in a customer channel (typically Slack Connect), although you can always adjust this from your Slack settings
 
 If you want to opt out of unfurling completely, you can disable thread discussions and link unfurling in your Slack integration settings.

--- a/thread-discussions.mdx
+++ b/thread-discussions.mdx
@@ -14,7 +14,7 @@ For your convenience, the discussion will also be visible in the Plain thread.
 To enable this functionality, you will need to setup your [Slack integration](/slack) and add the Plain bot to your channel.
 
 <Warning>
-  When Plain is added to a channel, we automatically classify it as a [Customer channel](/slack/how-slack-messages-create-threads) if it's a slack connect channel or one for internal discussions otherwise.
+  When Plain is added to a channel, we automatically classify it as a [Customer channel](/slack/how-slack-messages-create-threads) if it's a _Slack Connect_ channel or one for internal discussions otherwise.
 
 For customer channels, we treat messages from non-Plain users as support requests, which are ingested as threads into Plain.
 

--- a/thread-discussions.mdx
+++ b/thread-discussions.mdx
@@ -27,6 +27,6 @@ We will not start a discussion if:
 
 - the link is posted by someone who is not a user in Plain.
 - the link is posted in a private channel Plain doesn't have access to.
-- the link is posted in a customer channel (typically Slack Connect), although you can always adjust this from your Slack settings.
+- the link is posted in a customer channel (typically _Slack Connect_), although you can always adjust this from your Slack settings.
 
 If you want to opt out of unfurling completely, you can disable thread discussions and link unfurling in your Slack integration settings.


### PR DESCRIPTION
Added this to the slack page:
<img width="685" alt="image" src="https://github.com/team-plain/docs/assets/7642330/e4ebcf1d-a841-42a6-8d64-38e245eb8640">

And this to the thread discussions page:
<img width="675" alt="image" src="https://github.com/team-plain/docs/assets/7642330/9f781c1b-3a4e-40f9-ac24-b9217a462a3a">

there are also some other minor changes, ie punctuation, minor clarifications, etc.