### PR TITLE
Add docs for discourse and minor quickstart improvements

### DIFF
--- a/api-reference/graphql/messaging/reply-to-thread.mdx
+++ b/api-reference/graphql/messaging/reply-to-thread.mdx
@@ -36,7 +36,7 @@ This operation requires the following permission:
   [pricing page](https://www.plain.com/pricing).
 </Note>
 
-This feature allows you to bring native messaging between your customers and Plain, straight into [your own product](/api-reference/headless-portal).
+This feature allows you to bring native messaging between your customers and Plain, straight into [your own product](/headless-support-portal).
 
 With impersonation, you can reply to a thread on behalf of one of your customers: impersonated messages will show up as if they were sent by the customers themselves.
 

--- a/headless-support-portal.mdx
+++ b/headless-support-portal.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Headless Support Portal'
 description: 'Give your customers visibility over their support requests.'
+sidebarTitle: "Headless portal"
 ---
 
 <Warning>

--- a/headless-support-portal.mdx
+++ b/headless-support-portal.mdx
@@ -101,7 +101,7 @@ Depending on the channels you support your UI here might vary. For example if yo
 
 ### Example implementation
 
-To show you how this works we've built an example using NextJS which shows how you might set up a headless support portal. 
+To show you how this works we've built an example using NextJS which shows how you might set up a headless support portal.
 
 **[Check out the example on Github →](https://github.com/team-plain/example-headless-portal)**
 

--- a/headless-support-portal.mdx
+++ b/headless-support-portal.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Headless Support Portal'
 description: 'Give your customers visibility over their support requests.'
-sidebarTitle: "Headless portal"
+sidebarTitle: 'Headless portal'
 ---
 
 <Warning>

--- a/headless-support-portal.mdx
+++ b/headless-support-portal.mdx
@@ -99,8 +99,14 @@ Depending on the channels you support your UI here might vary. For example if yo
 </Step>
 </Steps>
 
+### Example implementation
+
+To show you how this works we've built an example using NextJS which shows how you might set up a headless support portal. 
+
+**[Check out the example on Github →](https://github.com/team-plain/example-headless-portal)**
+
 ---
 
 There is a lot of more nuance and detail that these docs do not cover such as rich formatting, attachments etc. We can help you plan and scope out the necessary work depending on your exact requirements and stack. We can also debug technical issues as well as actually help with the implementation in your code base.
 
-If you are interested in building a headless support portal based on this high-level overview, please reach out to us on sales@plain.com.
+If you are interested in building a headless support portal based on this high-level overview, please reach out to us via Plain or on help@plain.com.

--- a/integrations/discourse.mdx
+++ b/integrations/discourse.mdx
@@ -1,0 +1,14 @@
+---
+title: 'Discourse Integration'
+---
+
+With Plain you can connect your Discourse community and automatically keep track of support requests via Plain.
+
+This works by deploying a small node service which uses Plain and Discourse's APIs. You can either self-host this little node service or we can deploy this for you. 
+
+**[Check out the example on Github →](https://github.com/team-plain/example-discourse-integration)**
+
+This integration can be customised depending on the structure of your Discourse community and ideal support workflow. For example you could customise the priority, labels and assignee of support requests from Discourse based on their category, author and content. 
+
+If you'd like help getting this set up, just reach out to us via Plain or on help@plain.com.
+

--- a/integrations/discourse.mdx
+++ b/integrations/discourse.mdx
@@ -4,11 +4,10 @@ title: 'Discourse Integration'
 
 With Plain you can connect your Discourse community and automatically keep track of support requests via Plain.
 
-This works by deploying a small node service which uses Plain and Discourse's APIs. You can either self-host this little node service or we can deploy this for you. 
+This works by deploying a small node service which uses Plain and Discourse's APIs. You can either self-host this little node service or we can deploy this for you.
 
 **[Check out the example on Github →](https://github.com/team-plain/example-discourse-integration)**
 
-This integration can be customised depending on the structure of your Discourse community and ideal support workflow. For example you could customise the priority, labels and assignee of support requests from Discourse based on their category, author and content. 
+This integration can be customised depending on the structure of your Discourse community and ideal support workflow. For example you could customise the priority, labels and assignee of support requests from Discourse based on their category, author and content.
 
 If you'd like help getting this set up, just reach out to us via Plain or on help@plain.com.
-

--- a/mint.json
+++ b/mint.json
@@ -81,11 +81,12 @@
 						"email/alternate-emails"
 					]
 				},
-				"contact-forms",
 				{
 					"group": "Slack",
 					"pages": ["slack", "slack/ingestion-modes", "slack/data-retention"]
-				}
+				},
+				"contact-forms",
+				"headless-support-portal"
 			]
 		},
 		{
@@ -111,7 +112,8 @@
 			"pages": [
 				"integrations/linear",
 				"integrations/salesforce",
-				"integrations/zendesk"
+				"integrations/zendesk",
+				"integrations/discourse"
 			]
 		},
 		{
@@ -269,7 +271,6 @@
 						"api-reference/ui-components/text"
 					]
 				},
-				"api-reference/headless-portal",
 				"api-reference/attachments"
 			]
 		}
@@ -278,5 +279,11 @@
 		"twitter": "https://twitter.com/plainsupport",
 		"linkedin": "https://www.linkedin.com/company/plainsupport",
 		"github": "https://github.com/team-plain/docs"
-	}
+	},
+	"redirects": [
+		{
+			"source": "/api-reference/headless-portal",
+			"destination": "/headless-support-portal"
+		}
+	]
 }

--- a/plain-ai.mdx
+++ b/plain-ai.mdx
@@ -2,7 +2,9 @@
 title: 'Plain AI'
 ---
 
-Quickly categorize and label new threads without lifting a finger. To turn on Plain’s AI features, go to **Settings → Workflow.\***
+Quickly categorize and label new threads without lifting a finger. To turn on Plain’s AI features, go to **Settings → Workflow.**
+
+All AI features in Plain are opt-in. More information on our use of OpenAI and our data processing policies can be found in our [DPA](https://www.plain.com/legal/dpa).
 
 <Frame>![Plain AI](/public/images/plain-ai.png)</Frame>
 
@@ -10,8 +12,10 @@ Quickly categorize and label new threads without lifting a finger. To turn on Pl
 
 When a thread is created, Plain AI will add 1-2 labels automatically to a thread based on its content. If a thread was created with existing labels, no labels will be added. To best leverage Plain AI, make sure you’ve already set up [Labels](/labels) (**Settings → Labels**).
 
+**Thread titles**
+
+When enabled, this will automatically give each thread a human readable title based on the content of the support request. This is particularly useful in Slack and other channels which, unlike email, do not have a subject line you can rely on.
+
 **Thread summarization**
 
 As a thread grows over time, a summary of the thread will be added and kept up-to-date so you know what has happened without having to read the full timeline and every message. You can see the summary on the top right of any thread and in Slack notifications.
-
-**\*** All AI features in Plain are opt-in. More information on our use of OpenAI and our data processing policies can be found in our [DPA](https://www.plain.com/legal/dpa).

--- a/plain-ai.mdx
+++ b/plain-ai.mdx
@@ -14,7 +14,7 @@ When a thread is created, Plain AI will add 1-2 labels automatically to a thread
 
 **Thread titles**
 
-When enabled, this will automatically give each thread a human readable title based on the content of the support request. This is particularly useful in Slack and other channels which, unlike email, do not have a subject line you can rely on.
+When enabled, this will automatically give each thread a short, descriptive title based on the content of the support request. This is particularly useful in Slack and other channels which, unlike email, do not have a subject line you can rely on.
 
 **Thread summarization**
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -25,7 +25,7 @@ To start answering customer requests in Plain, you should begin by connecting yo
 
 **Email** – You can link your support email and start receiving customer request in minutes. For more information on how to connect your email addresses to Plain, [check out the docs](/email/)
 
-You can also build a totally on-brand [support portal](/headless-portal/) and [in-app forms](/contact-forms/) to match your branding and UI, and structure your support queries.
+You can also build a totally on-brand [support portal](/headless-support-portal/) and [in-app forms](/contact-forms/) to match your branding and UI, and structure your support queries.
 
 </Accordion>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,29 +1,31 @@
 ---
 title: 'Quickstart'
-description: 'Everything you need to start using Plain.'
+description: 'Everything you need to know to start supporting your customers with Plain.'
 ---
 
 <Frame>![Plain.com](/public/images/quickstart.png)</Frame>
 
-Plain is the support platform for B2B technical teams. Everything you need to help your customers in a modern, fast, and opinionated platform.
+Plain is the fastest, most powerful support platform for B2B startups. It's got everything you need to help your customers in a modern, collaborative, and consolidated platform.
 
-This quickstart will walk you through how to start helping customers and get the most out of Plain.
+This quickstart guide will walk you through how to set up your workspace and start helping your customers.
 
 ### The basics
 
 <AccordionGroup>
+
 <Accordion title="Create a workspace" icon="seedling">
-Everything within Plain happens in a workspace. To create a workspace for your team, sign up at https://app.plain.com and click **Create a workspace**.
+Everything in Plain happens in your team's workspace. To create a workspace for your team, sign up at https://app.plain.com and click **Create a workspace**.
 
 </Accordion>
+
 <Accordion title="Set up your channels" icon="comments">
-There are three ways to receive questions in Plain – email, contact forms or Slack.
+To start answering customer requests in Plain, you should begin by connecting your Slack and/or email:
 
-**Email** – When you create a workspace you will be guided through email set-up automatically. For more information on how it works [check out the docs](/email/)
+**Slack** - Our Slack integration lets you sync messages from selected Slack channels to Plain and respond directly to customers from the platform. [Learn more about setting up Slack with Plain](/slack).
 
-**Contact forms (Optional)** – Forms are a great way to offer support at scale. Use [these instructions](/contact-forms/) to set up a form or a floating widget.
+**Email** – You can link your support email and start receiving customer request in minutes. For more information on how to connect your email addresses to Plain, [check out the docs](/email/)
 
-**Slack** - Our Slack integration lets you sync messages from selected Slack channels to Plain and respond directly to customers from the platform. [Find out more here](/slack).
+You can also build a totally on-brand [support portal](/headless-portal/) and [in-app forms](/contact-forms/) to match your branding and UI, and structure your support queries. 
 
 </Accordion>
 
@@ -34,7 +36,7 @@ There are three ways to receive questions in Plain – email, contact forms or S
 </Accordion>
 
 <Accordion title="Set up notifications" icon="bell">
-To be notified of new support requests, [set up notifications](/notifications).
+To make sure your team gets notified of new support requests, [set up notifications](/notifications).
 
 We recommend, as a minimum, setting up one shared Slack or Discord channel where new support requests are posted. We also recommend setting up personal notifications so you can be notified of new replies and activity on threads you are assigned to.
 
@@ -43,7 +45,7 @@ We recommend, as a minimum, setting up one shared Slack or Discord channel where
 <Accordion title="Connect your Linear workspace" icon="link">
 [Connecting your Linear workspace](/integrations/linear) to Plain will let you quickly and seamlessly log bugs and feature requests to Linear without leaving Plain and then close the loop with the customer once they're completed.
 
-You can connect to Linear from **Settings** → **Linear**.
+You can connect to Linear by selecting your workspace name in the top left hand side of your Plain workspace, and selecting **Settings** → **Linear**.
 
 </Accordion>
 
@@ -54,26 +56,74 @@ You can connect to Linear from **Settings** → **Linear**.
 <AccordionGroup>
 
 <Accordion title="Add labels" icon="tag">
-  Labels are a lightweight but powerful way to categorize threads in Plain. You can configure the labels that make sense for you in **Settings** → **Labels**.
+ Labels are a lightweight but powerful way to categorize threads in Plain. You can configure the labels that make sense for you in **Settings** → **Labels**.
 
 [**Add labels**](/labels/)
 
 </Accordion>
 
 <Accordion title="Set up snippets" icon="feather">
-  Snippets are templated messages that allow you to pull common language to message customers more
-  quickly. You can configure them in **Settings** → **Snippets**
+ Snippets are templated messages that allow you to pull common language to message customers more
+ quickly. You can configure them in **Settings** → **Snippets**
 
 [**Set up snippets**](/snippets/)
 
 </Accordion>
 
+<Accordion title="Add auto-responders" icon="reply">
+ An autoresponder can be useful in situations of acute support load, such as during incidents, or to confirm you received a support request and manage expectations with customers.
+
+[**Set up auto-responses**](/auto-responses/)
+
+</Accordion>
+
 <Accordion title="Learn keyboard shortcuts" icon="keyboard">
-  We make it easy to fly through your workflow without ever needing to use a mouse. Learn about our
-  keyboard shortcuts here. We've also added hints throughout the app on which keyboard shortcuts to
-  use.
+ We make it easy to fly through your workflow without ever needing to use a mouse. Learn about our
+ keyboard shortcuts here. We've also added hints throughout the app on which keyboard shortcuts to
+ use.
 
 [**View all shortcuts**](/shortcuts/)
+
+</Accordion>
+
+</AccordionGroup>
+
+### Organize your workspace
+
+<AccordionGroup>
+
+<Accordion title="Companies" icon="building">
+ In Plain you can see what company a customer belongs to, so you have more context when providing support.
+
+[**Learn more about companies**](/company-support/)
+
+</Accordion>
+
+<Accordion title="Tenants" icon="house">
+ You can organize your customers to mirror how your product is structured. For example, if in your product all of your customers belong to a team/org/account/workspace then you would create a tenant per team/org/account/workspace.
+
+[**Learn more about tenants**](/tenant-support/)
+
+</Accordion>
+
+<Accordion title="Tiers" icon="sort">
+ Tiers add support for defining SLAs so you can enforce a first-response time for different support tiers within your product or pricing.
+
+[**Learn more about tiers**](/data-model/)
+
+</Accordion>
+
+<Accordion title="SLAs" icon="clock">
+ When configuring an SLA you can set when you want to be warned of a breach. For example if your first response time SLA is 4 hours, you might want to be notified 30 minutes before a breach so you can still reply in time. They can be set for first response time and next response time.
+
+[**Learn more about SLAs**](/tiers#slas/)
+
+</Accordion>
+
+<Accordion title="Business Hours" icon="keyboard">
+ By default, SLAs apply at all times. They can be configured to only count working hours by toggling on Only during business hours. To configure business hours go to Settings → Business hours.
+
+[**Learn more about business hours**](/tiers#business-hours/)
 
 </Accordion>
 
@@ -90,10 +140,18 @@ Customer cards let you show live information from your own systems in Plain. Thi
 [**Set up customer cards**](/customer-cards/)
 
 </Accordion>
+
 <Accordion title="Log key events" icon="code">
 Events let you log important customer actions, errors, releases, and other key events to Plain. This gives you the full picture in the context of a support request as to what happened and why.
 
 [**Set up events**](/events/)
+
+</Accordion>
+
+<Accordion title="Thread fields" icon="code">
+To be able to keep track of additional information related to a support request, you can configure additional custom fields you want to store on a thread (like product area, needs followup, Github issue etc.).
+
+[**Learn more about thread fields**](/thread-fields/)
 
 </Accordion>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -25,7 +25,7 @@ To start answering customer requests in Plain, you should begin by connecting yo
 
 **Email** – You can link your support email and start receiving customer request in minutes. For more information on how to connect your email addresses to Plain, [check out the docs](/email/)
 
-You can also build a totally on-brand [support portal](/headless-portal/) and [in-app forms](/contact-forms/) to match your branding and UI, and structure your support queries. 
+You can also build a totally on-brand [support portal](/headless-portal/) and [in-app forms](/contact-forms/) to match your branding and UI, and structure your support queries.
 
 </Accordion>
 


### PR DESCRIPTION
This adds documentation for Discourse as well as:

- moves headless portal docs to be under Channels top-level
- introduces improvements to Quickstart which we've been meaning to publish for a while