### PR TITLE
Fix duplicate "For example" in tenant description

### DIFF
--- a/data-model.mdx
+++ b/data-model.mdx
@@ -53,7 +53,7 @@ You can filter and organise your support by company.
 
 ## Tenants
 
-Tenants allow you organise your customers in the same way they are organised in your product. For example. For example if your product's users are organised into teams then every team would be one tenant within Plain.
+Tenants allow you to organise your customers in the same way they are organised in your product. For example, if your product's users are organised into teams, then every team would be one tenant within Plain.
 
 Tenants can only be created programmatically and are useful for advanced integrations or larger support teams.
 


### PR DESCRIPTION
- Remove repeated phrase
- Add missing "to" after "allow you"
- Improve punctuation for better readability