### PR TITLE
Update example GitHub Actions indexing workflow

### DIFF
--- a/plain-ai/knowledge-sources.mdx
+++ b/plain-ai/knowledge-sources.mdx
@@ -39,14 +39,14 @@ on:
     - cron: '0 */3 * * *'
 
 jobs:
-  lint:
+  index:
     name: Index Documents
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install CLI
         run: npm install -g @team-plain/cli@latest
@@ -54,5 +54,5 @@ jobs:
       - name: Index Documents
         run: plain index-sitemap https://www.plain.com/docs/sitemap.xml --labelTypeIds lt_01G0EZ1XTM37C643SQTDNXR1
         env:
-          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY }}`
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY }}
 ```


### PR DESCRIPTION
This makes a few minor edits to the example GitHub Actions workflow for docs indexing:

1. Update the job ID (`s/lint/index/`)
2. Update the Actions to the latest versions to avoid deprecation warnings
3. Remove a stray backtick at the end of the example