### PR TITLE
Index docs to demo workspace

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -17,8 +17,13 @@ jobs:
 
       - name: Install CLI
         run: npm install -g @team-plain/cli@latest
-
-      - name: Index Docs
+        
+      - name: Index Docs (prod)
         run: plain index-sitemap https://www.plain.com/docs/sitemap.xml
         env:
           PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY }}
+
+      - name: Index Docs (demo workspace)
+        run: plain index-sitemap https://www.plain.com/docs/sitemap.xml
+        env:
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY_DEMO_WORKSPACE }}


### PR DESCRIPTION
So we can demo the agent / suggested responses using our documentation / help center, I've added an index job for the [Plain Demo Workspace](https://app.plain.com/workspace/w_01H0J90EVVNJN5JNPC61DQZWAT/?sort=status-changed-asc&groupBy=priority) 

Added the new secret https://github.com/team-plain/docs/settings/secrets/actions from [this machine user](https://app.plain.com/workspace/w_01H0J90EVVNJN5JNPC61DQZWAT/settings/machine-users/mu_01K0PE0XTK6H25AZHP6HD1B7FH/)