### PR TITLE
fix: Set up redirect for invalid /api-reference/*

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -218,6 +218,10 @@
 		{
 			"source": "/headless-portal",
 			"destination": "/headless-support-portal"
+		},
+		{
+			"source": "/api-reference/:slug*",
+			"destination": "/:slug*"
 		}
 	]
 }


### PR DESCRIPTION
It looks like these routes were renamed to remove the prefix in #213.

We still have some docs ([example](https://plain.support.site/article/contact-forms-overview#getting-started-with-contact-forms)) linking out to the /api-reference prefixed pages, which we should change at some point but this seems like a more robust move to catch all those cases.

([Mintlify docs](https://www.mintlify.com/docs/create/broken-links#redirects))